### PR TITLE
Add 'timestamper' plugin

### DIFF
--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -17,6 +17,7 @@ matrix-auth
 sshd
 ssh-slaves
 strict-crumb-issuer
+timestamper
 workflow-aggregator
 workflow-multibranch
 ws-cleanup

--- a/jenkins-jobs/update.sh
+++ b/jenkins-jobs/update.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 git clone https://opendev.org/jjb/jenkins-job-builder.git
 cd jenkins-job-builder
+source .venv/bin/activate
 virtualenv .venv
 pip install -r test-requirements.txt -e .
 python jenkins_jobs/__main__.py --user tvm-bot --password $1 --conf "/home/ubuntu/jenkins-jobs/$2/jenkins_jobs.ini" update "/home/ubuntu/jenkins-jobs/$2"
+


### PR DESCRIPTION
This is a pretty popular plugin that adds timestamps to each log line: https://plugins.jenkins.io/timestamper/

This will be nice for checking how long certain things take in CI without relying on individual tools in CI (e.g. like pytest `--durations`)

cc @areusch @konturn 
