### PR TITLE
fix: use GITHUB_WORKSPACE variable to refer to root of repository on …

### DIFF
--- a/ansible/roles/setup_jenkins_head/tasks/main.yml
+++ b/ansible/roles/setup_jenkins_head/tasks/main.yml
@@ -146,7 +146,7 @@
 
 - name: Copy over reload script
   ansible.builtin.copy:
-    src: "{{ lookup('env', 'CI_PROJECT_DIR') + '/scripts/reload.sh' }}"
+    src: "{{ lookup('env', 'GITHUB_WORKSPACE') + '/scripts/reload.sh' }}"
     dest: "/home/ubuntu"
     owner: 1000
     group: 1000


### PR DESCRIPTION
…ansible controller