### PR TITLE
Add prometheus plugin

### DIFF
--- a/docker/plugins.txt
+++ b/docker/plugins.txt
@@ -22,3 +22,5 @@ workflow-aggregator
 workflow-multibranch
 ws-cleanup
 pipeline-github-lib
+prometheus
+


### PR DESCRIPTION
This adds the prometheus plugin so we can scrape metrics and at least have some monitoring going on until we can get Datadog access

cc @areusch 