### PR TITLE
Fix core_pattern and ulimit settings

### DIFF
--- a/packer/base-images/scripts/coredumps.sh
+++ b/packer/base-images/scripts/coredumps.sh
@@ -7,7 +7,20 @@ set -o pipefail
 mkdir -p /var/crash
 
 # tell the kernel to put them in that directory
-sysctl -w kernel.core_pattern=/var/crash/coredump-%e.%p.%h.%t
+echo "
+kernel.core_pattern=/var/crash/coredump-%e.%p.%h.%t
+" >> /etc/sysctl.conf
+
+# turn off apport
+echo "
+enabled=0
+" > /etc/default/apport
+systemctl disable apport.service
+systemctl mask apport.service
 
 # remove the limit on core dump size
-ulimit -c unlimited
+echo "
+*    soft    core unlimited
+*    hard    core unlimited
+
+" > /etc/security/limits.d/core.conf


### PR DESCRIPTION
These before didn't persist across reboots so they were basically
useless in an AMI. I tested these changes in packer and on AWS and it
successfully creates a core dump with no extra configuration necessary.
