### PR TITLE
Add arch-specific prefix to all AMIs

### DIFF
--- a/packer/base-images/aws/base-image.pkr.hcl
+++ b/packer/base-images/aws/base-image.pkr.hcl
@@ -6,10 +6,10 @@ source "amazon-ebs" "aws_base_image" {
   access_key = var.aws_access_key  
   secret_key =  var.aws_secret_key
   communicator        = "ssh"
-  ami_name          = "${var.image_prefix}-v${var.buildtime}"
+  ami_name          = "${var.image_prefix}-x64-v${var.buildtime}"
   ami_groups = ["all"]
   tags = {
-    image_family = "${var.image_prefix}"
+    image_family = "${var.image_prefix}-x64"
   }
   instance_type        = "t2.micro"
   source_ami_filter {

--- a/packer/jenkins-agents/gpu/gpu-jenkins-agent.pkr.hcl
+++ b/packer/jenkins-agents/gpu/gpu-jenkins-agent.pkr.hcl
@@ -8,14 +8,14 @@ source "amazon-ebs" "jenkins_gpu_image" {
   secret_key =  var.aws_secret_key
   communicator        = "ssh"
   ami_groups = ["all"]
-  ami_name          = "${var.image_prefix}-v${var.buildtime}"
+  ami_name          = "${var.image_prefix}-x64-v${var.buildtime}"
   tags = {
-    image_family = "${var.image_prefix}"
+    image_family = "${var.image_prefix}-x64"
   }
   source_ami_filter {
     filters = {
     virtualization-type = "hvm"
-    "tag:image_family" = "${var.source_image_family}"
+    "tag:image_family" = "${var.source_image_family}-x64"
     root-device-type = "ebs"
     }
     owners = ["self"]

--- a/packer/jenkins-agents/stock/stock-jenkins.pkr.hcl
+++ b/packer/jenkins-agents/stock/stock-jenkins.pkr.hcl
@@ -6,16 +6,16 @@ source "amazon-ebs" "jenkins_stock_image" {
   access_key = var.aws_access_key  
   secret_key =  var.aws_secret_key
   communicator        = "ssh"
-  ami_name          = "${var.image_prefix}-v${var.buildtime}"
+  ami_name          = "${var.image_prefix}-x64-v${var.buildtime}"
   ami_groups = ["all"]
   tags = {
-    image_family = "${var.image_prefix}"
+    image_family = "${var.image_prefix}-x64"
   }
   instance_type        = "t2.micro"
   source_ami_filter {
     filters = {
     virtualization-type = "hvm"
-    "tag:image_family" = "${var.source_image_family}"
+    "tag:image_family" = "${var.source_image_family}-x64"
     root-device-type = "ebs"
     }
     owners = ["self"]


### PR DESCRIPTION
Terraform gets confused with `image-name` and `image-name-arm`, so this adds `-x64` everywhere to disambiguate
