### PR TITLE
Bump retention from 10 -> 90 days

### DIFF
--- a/jenkins/jenkins-jobs/prod/tvm.yaml
+++ b/jenkins/jenkins-jobs/prod/tvm.yaml
@@ -24,6 +24,5 @@
                 - named-branches:
                     regex-name:
                         regex: "^(?!.*last-successful).*$"
-    days-to-keep: 10
-    number-to-keep: 10
+    days-to-keep: 90
     script-path: Jenkinsfile


### PR DESCRIPTION
This deletes builds older than 3~ish months and removes the deletion
rule based on the number of items
