### PR TITLE
Add ECR repo for ci_minimal

### DIFF
--- a/terraform/vars/tvm-ci-prod.auto.tfvars
+++ b/terraform/vars/tvm-ci-prod.auto.tfvars
@@ -79,6 +79,7 @@ autoscaler_types = {
 ecr_repositories = [
   "ci_arm",
   "ci_cpu",
+  "ci_minimal",
   "ci_gpu",
   "ci_hexagon",
   "ci_i386",


### PR DESCRIPTION
Adds an ECR repo for `ci_minimal`

Required for https://github.com/apache/tvm/pull/12178

@driazati 