### PR TITLE
Re-add ci_qemu

### DIFF
--- a/terraform/vars/tvm-ci-prod.auto.tfvars
+++ b/terraform/vars/tvm-ci-prod.auto.tfvars
@@ -85,6 +85,7 @@ ecr_repositories = [
   "ci_i386",
   "ci_lint",
   "ci_cortexm",
+  "ci_qemu",
   "ci_wasm"
 ]
 


### PR DESCRIPTION
This puts the ci_qemu repo back terraform until we complete the renaming
