### PR TITLE
[jenkins] Stop double-building of branches and PRs

### DIFF
--- a/jenkins/jenkins-jobs/prod/tvm.yaml
+++ b/jenkins/jenkins-jobs/prod/tvm.yaml
@@ -9,7 +9,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -39,7 +39,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -69,7 +69,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -99,7 +99,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -129,7 +129,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -159,7 +159,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -189,7 +189,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -219,7 +219,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -249,7 +249,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -279,7 +279,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -309,7 +309,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -339,7 +339,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -369,7 +369,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody
@@ -399,7 +399,7 @@
             repo: tvm
             repo-owner: apache
             credentials-id: 'tqchen-ci'
-            branch-discovery: all
+            branch-discovery: no-pr
             discover-pr-origin: current
             discover-pr-forks-strategy: current
             discover-pr-forks-trust: nobody


### PR DESCRIPTION
For PRs that are filed from a branch rather than a fork Jenkins has been
scheduling 2 builds, one for the branch and one for the PR head. We only
really need one and there is an easy option to exclude branches that are
filed as PRs from indexing, which this PR sets for all the tvm jobs.

docs: https://jenkins-job-builder.readthedocs.io/en/latest/project_workflow_multibranch.html#project_multibranch.github_scm