### PR TITLE
Update NVIDIA driver for CUDA 11.7

### DIFF
--- a/.github/workflows/packer_build.yml
+++ b/.github/workflows/packer_build.yml
@@ -53,8 +53,8 @@ jobs:
           WORKSPACE_DIR: jenkins-agents/stock
           PKR_VAR_source_image_family: jenkins-stock-agent
           PKR_VAR_image_prefix: jenkins-gpu-agent
-          #This driver version below is the latest recommended given our requirements (T4 GPU, CUDA 11.2, Linux X86). Furthermore, the corresponding run script is compatible with Linux kernel version 5.13.
-          PKR_VAR_nvidia_driver_version: "460.106.00"
+          #This driver version below is the latest recommended given our requirements (T4 GPU, CUDA 11.7, Linux X64). Furthermore, the corresponding run script is compatible with Linux kernel version 5.13.
+          PKR_VAR_nvidia_driver_version: "515.86.01"
           PKR_VAR_nvidia_driver_base_url: "https://us.download.nvidia.com/tesla"
         with:
           command: build


### PR DESCRIPTION
We need to update NV driver for https://github.com/apache/tvm/pull/14293

The selected driver is recommended by the NV site for CUDA 11.7 + T4 + x64 environment.
https://www.nvidia.com/download/driverResults.aspx/194653/en-us/