### PR TITLE
Add user permissions

### DIFF
--- a/jenkins/docker/prod/base_config.yaml
+++ b/jenkins/docker/prod/base_config.yaml
@@ -49,6 +49,7 @@ jenkins:
       - "USER:Overall/Administer:konturn"
       - "USER:Overall/Administer:lunderberg"
       - "USER:Overall/Administer:tvm-bot"
+      - "USER:Overall/Administer:liam-sturge"
       - "GROUP:Overall/Administer:octoml"
       - "GROUP:Overall/Administer:tlc-pack"
       - "USER:Overall/Read:anonymous"


### PR DESCRIPTION
Grant user `Liam-Sturge` permissions to administer the Jenkins tlc-pack CI.
Access required to test contribution of new Jenkins pipeline for generating AArch64 packages.

CC @areusch @driazati @leandron