### PR TITLE
Add PyPI API keys to Jenkins

### DIFF
--- a/jenkins/ansible/roles/setup_jenkins_head/tasks/main.yml
+++ b/jenkins/ansible/roles/setup_jenkins_head/tasks/main.yml
@@ -123,6 +123,22 @@
     group: 1000
     mode: 0600
 
+- name: PyPI API key
+  ansible.builtin.copy:
+    content: "{{ lookup('env', 'PYPI_TOKEN') }}"
+    dest: "/var/jenkins/keys/pypi-api-token"
+    owner: 1000
+    group: 1000
+    mode: 0600
+
+- name: test PyPI API key
+  ansible.builtin.copy:
+    content: "{{ lookup('env', 'TEST_PYPI_TOKEN') }}"
+    dest: "/var/jenkins/keys/test-pypi-api-token"
+    owner: 1000
+    group: 1000
+    mode: 0600
+
 - name: Base configuration for Jenkins
   ansible.builtin.copy:
     src: "{{ lookup('env', 'GITHUB_WORKSPACE') + '/jenkins/docker/' + lookup('env', 'ENVIRONMENT') + '/base_config.yaml' }}"

--- a/jenkins/docker/prod/base_config.yaml
+++ b/jenkins/docker/prod/base_config.yaml
@@ -189,3 +189,11 @@ credentials:
               owner: "octoml"
               description: "GitHub App for octoml/relax repos"
               privateKey: "${readFile:/key/octoml_relax_ci_github_app_key}"
+          - string:
+              id: "pypi-api-token"
+              description: "key for pushing TLCPack to PyPI"
+              secret: "${readFile:/key/pypi-api-token}"
+          - string:
+              id: "test-pypi-api-token"
+              description: "key for pushing TLCPack to test PyPI"
+              secret: "${readFile:/key/test-pypi-api-token}"


### PR DESCRIPTION
Credentials have been added for PyPI uploading, which will persist on redeployment of the Jenkins instance.

cc @areusch @tqchen