### PR TITLE
Add Graviton3 r7g instance to Terraform vars

### DIFF
--- a/terraform/vars/tvm-ci-prod.auto.tfvars
+++ b/terraform/vars/tvm-ci-prod.auto.tfvars
@@ -121,7 +121,7 @@ autoscaler_types = {
   }
   "Prod-Autoscaler-Jenkins-ARM-Graviton3" = {
     image_family                             = "jenkins-stock-agent-arm"
-    agent_instance_type                      = "c7g.large"
+    agent_instance_type                      = "r7g.large"
     labels                                   = "ARM-GRAVITON3"
     min_size                                 = 0
     max_size                                 = 90
@@ -130,7 +130,7 @@ autoscaler_types = {
   }
   "Prod-Autoscaler-Jenkins-ARM-Graviton3-SPOT" = {
     image_family                               = "jenkins-stock-agent-arm"
-    agent_instance_type                        = "c7g.large"
+    agent_instance_type                        = "r7g.large"
     labels                                     = "ARM-GRAVITON3-SPOT"
     min_size                                   = 0
     max_size                                   = 90


### PR DESCRIPTION
Replacing c7g.large nodes with r7g, which has more memory and less CPU cores.

Reason for change:
  1. The c7g nodes did not have enough memory to support CI.
  2. With less cores this will be more cost effective.

cc @leandron @mousius @areusch @tqchen