### PR TITLE
Update NVIDIA driver for CUDA 12.2

### DIFF
--- a/.github/workflows/packer_build.yml
+++ b/.github/workflows/packer_build.yml
@@ -53,8 +53,8 @@ jobs:
           WORKSPACE_DIR: jenkins-agents/stock
           PKR_VAR_source_image_family: jenkins-stock-agent
           PKR_VAR_image_prefix: jenkins-gpu-agent
-          #This driver version below is the latest recommended given our requirements (T4 GPU, CUDA 11.7, Linux X64). Furthermore, the corresponding run script is compatible with Linux kernel version 5.13.
-          PKR_VAR_nvidia_driver_version: "515.86.01"
+          #This driver version below is the latest recommended given our requirements (T4 GPU, CUDA 12.2, Linux X64). Furthermore, the corresponding run script is compatible with Linux kernel version 5.13.
+          PKR_VAR_nvidia_driver_version: "535.129.03"
           PKR_VAR_nvidia_driver_base_url: "https://us.download.nvidia.com/tesla"
         with:
           command: build


### PR DESCRIPTION
Current CUDA driver is 11.7 while the CI images are 11.8. We have to use `NVIDIA_DISABLE_REQUIRE` to disable version check in https://github.com/apache/tvm/pull/16344. This PR upgrades the driver version to be the latest available for T4.

cc @masahi @yongwww @tqchen 