### PR TITLE
Add larger root volume for gpu image build

### DIFF
--- a/packer/jenkins-agents/gpu/gpu-jenkins-agent.pkr.hcl
+++ b/packer/jenkins-agents/gpu/gpu-jenkins-agent.pkr.hcl
@@ -12,6 +12,12 @@ source "amazon-ebs" "jenkins_gpu_image" {
   tags = {
     image_family = "${var.image_prefix}-x64"
   }
+  launch_block_device_mappings {
+    device_name = "/dev/sda1"
+    volume_size = 40
+    volume_type = "gp2"
+    delete_on_termination = true
+  }
   source_ami_filter {
     filters = {
     virtualization-type = "hvm"


### PR DESCRIPTION
Installing newer cuda driver need larger storage space for intermediate results. This fixed error in https://github.com/tlc-pack/ci/actions/runs/7453443286

cc @masahi @yongwww @tqchen 