### PR TITLE
Remove docker python package

### DIFF
--- a/packer/jenkins-agents/stock/configure-jenkins.sh
+++ b/packer/jenkins-agents/stock/configure-jenkins.sh
@@ -15,7 +15,6 @@ apt install -y build-essential
 apt install -y python3 python3-pip
 pip install -q poetry launchpadlib
 apt install -y openjdk-17-jre-headless
-pip install docker
 
 #echo new cron into cron file
 echo '0 * * * * docker system prune --all --force --filter "until=1h"' | crontab


### PR DESCRIPTION
Docker python package depends on urllib3 that's not compatible with awscli. Removed the python package since it is currently not used.

cc @tqchen 