### PR TITLE
[packer] Bump AWS base image to Ubuntu 24.04 (noble)

### DIFF
--- a/packer/base-images/aws/base-image.pkr.hcl
+++ b/packer/base-images/aws/base-image.pkr.hcl
@@ -23,7 +23,7 @@ source "amazon-ebs" "aws_base_image" {
   source_ami_filter {
     filters = {
     virtualization-type = "hvm"
-    name = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-*"
+    name = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"
     root-device-type = "ebs"
     }
     owners = ["099720109477"]
@@ -45,7 +45,7 @@ source "amazon-ebs" "aws_base_image_arm" {
   source_ami_filter {
     filters = {
     virtualization-type = "hvm"
-    name = "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-arm64-server-*"
+    name = "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-arm64-server-*"
     root-device-type = "ebs"
     }
     owners = ["099720109477"]


### PR DESCRIPTION
Move the amd64 and arm64 source_ami_filter name patterns from jammy 22.04 to noble 24.04. Note the image path prefix changed from hvm-ssd to hvm-ssd-gp3 (Canonical switched the default root volume gp2->gp3 starting 23.10), so a plain codename swap that kept hvm-ssd would match zero AMIs.